### PR TITLE
[other]添加 apigw 的打印日志

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ const wsAllowAccess = function(event, email) {
 }
 
 exports.handler = function (event, context) {
+  if (event.requestContext) {
+    console.log("x-apigw-request-id: " + event.requestContext.requestId);
+  }
   let accessToken;
   let allowAccessFunction;
   if (event.authorizationToken) {


### PR DESCRIPTION
为方便排查 auth lambda 日志，添加 apigw req id。
auth lambda 日志：
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/8be8952a-9f4e-4301-bc49-a8c1bc929ffd">

对应 apigw 日志：
<img width="1201" alt="image" src="https://github.com/user-attachments/assets/09f99034-cda8-4687-94bc-13d60aa506ec">

