### PR TITLE
Support request auth type for RESTAPI GW

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,10 @@ exports.handler = function (event, context) {
   if (event.authorizationToken) {
     accessToken = event.authorizationToken.split(" ")[1];
     allowAccessFunction = httpAllowAccess;
+  } else if(event.headers && (event.headers.Authorization || event.headers.authorization)) {
+    let bearerToken = event.headers.Authorization || event.headers.authorization;
+    accessToken = bearerToken.split(" ")[1];
+    allowAccessFunction = httpAllowAccess;
   } else if (event.queryStringParameters.AuthToken) {
     accessToken = event.queryStringParameters.AuthToken;
     allowAccessFunction = wsAllowAccess;


### PR DESCRIPTION
支持API Gateway为RestAPI时，Auth类型为Request时的场景，以兼容AWS China解析New-Authorizer的Header字段