### PR TITLE
[verifyToken]支持兼容 deprecated token

### DIFF
--- a/verify-token.js
+++ b/verify-token.js
@@ -15,6 +15,14 @@ const oktaJwtVerifier = new OktaJwtVerifier({
   },
 });
 
+const deprecatedOktaJwtVerifier = new OktaJwtVerifier({
+  issuer: process.env.DEPRECATED_ISSUER, // required
+  clientId: process.env.DEPRECATED_CLIENT_ID, // required
+  assertClaims: {
+    aud: process.env.DEPRECATED_AUDIENCE,
+  },
+});
+
 const transpileToComEmail = (email) =>
   email.endsWith("@hongshan.cn")
     ? email.replace("@hongshan.cn", "@hongshan.com")
@@ -167,7 +175,32 @@ module.exports.verifyAccessToken = function verifyAccessToken(
         const decoded = jsonWebToken.decode(accessToken);
 
         console.error("Decoded Okta token is " + JSON.stringify(decoded));
-        return context.fail("Unauthorized");
+
+        // 等去掉deprecated Okta verifier的时候，这里可以恢复return
+        // return context.fail('Unauthorized');
+
+        deprecatedOktaJwtVerifier
+          .verifyAccessToken(accessToken, process.env.DEPRECATED_AUDIENCE)
+          .then((jwt) => {
+            // the token is valid (per definition of 'valid' above)
+            console.log(
+              "okta request principal: " + JSON.stringify(jwt.claims)
+            );
+
+            const policy = allowAccess(event, jwt.claims.sub);
+            console.log(`Auth succeed as ${jwt.claims.sub}`);
+            const newContext = policy.build({
+              principalId: transpileToComEmail(jwt.claims.sub),
+            });
+            return context.succeed(newContext);
+          })
+          .catch((err) => {
+            console.log(err);
+            const decoded = jsonWebToken.decode(accessToken);
+
+            console.error("Decoded Okta token is " + JSON.stringify(decoded));
+            return context.fail("Unauthorized");
+          });
       });
   }
 };


### PR DESCRIPTION
切换 okta issuer 涉及的服务比较多，为了不影响其他开发人员，并为将来可能的生产切换做演练，调整 auth lambda，让其兼容新旧 issuer，保持服务稳定性。

pick from #16